### PR TITLE
removing reading from stdout for k6 output & fixing json parsing forescaped backslash and double quotes for http multistep

### DIFF
--- a/pkg/worker/check.go
+++ b/pkg/worker/check.go
@@ -361,7 +361,8 @@ func (cs *CheckState) update() {
 		firingLock.Unlock()
 
 		if !lock.TryLock() {
-			slog.Info("not allowed to run twice at same time")
+			slog.Info("not allowed to run twice at same time", slog.Int("id", c.Id),
+				slog.String("Uid", c.Uid))
 			return
 		}
 

--- a/pkg/worker/k6.osexec.go
+++ b/pkg/worker/k6.osexec.go
@@ -41,8 +41,12 @@ func findValueToPattern(input string, pattern string) string {
 	}
 	re = regexp.MustCompile(`\\/"`)
 	val = re.ReplaceAllString(val, `"`)
-	re1 := regexp.MustCompile(`\\"`)
-	val = re1.ReplaceAllString(val, `"`)
+
+	re1 := regexp.MustCompile(`\\\\"`)
+	val = re1.ReplaceAllString(val, `\"`)
+
+	re2 := regexp.MustCompile(`\\"`)
+	val = re2.ReplaceAllString(val, `"`)
 	return val
 }
 
@@ -64,10 +68,10 @@ func (k6Scripter *defaultK6Scripter) execute(scriptSnippet string) (string, erro
 
 	cmd := exec.Command("k6", "run", temp.Name())
 
-	stdoutPipe, outErr := cmd.StdoutPipe()
+	/*stdoutPipe, outErr := cmd.StdoutPipe()
 	if outErr != nil {
 		return "", fmt.Errorf("error creating stdout pipe: %s", outErr.Error())
-	}
+	}*/
 	stderrPipe, stdErr := cmd.StderrPipe()
 	if stdErr != nil {
 		return "", fmt.Errorf("error creating stderr pipe: %s", stdErr.Error())
@@ -77,10 +81,10 @@ func (k6Scripter *defaultK6Scripter) execute(scriptSnippet string) (string, erro
 		return "", fmt.Errorf("error starting k6 command: %s", err.Error())
 	}
 
-	outputBytes, err := readStdoutPipeLines(stdoutPipe)
+	/*outputBytes, err := readStdoutPipeLines(stdoutPipe)
 	if err != nil {
 		return "", fmt.Errorf("error reading stdout: %s", err.Error())
-	}
+	}*/
 	errorOutputBytes, err := readStdoutPipeLines(stderrPipe)
 	if err != nil {
 		return "", fmt.Errorf("error reading stderr: %s", err.Error())
@@ -93,9 +97,9 @@ func (k6Scripter *defaultK6Scripter) execute(scriptSnippet string) (string, erro
 
 	pattern1 := `###START->([^=]+)<-END###`
 	respValue := findValueToPattern(string(errorOutputBytes), pattern1)
-	if respValue == "" {
+	/*if respValue == "" {
 		respValue = findValueToPattern(string(outputBytes), pattern1)
-	}
+	}*/
 
 	//pattern2 := `###OTHER_START->([^=]+)<-OTHER_START###`
 	//other := findValueToPattern(string(errorOutputBytes), pattern2)
@@ -328,10 +332,10 @@ func CreateScriptSnippet(req SyntheticCheck) string {
 				"http_method":  step.Request.HTTPMethod,
 				"http_headers": step.Request.HTTPHeaders,
 				"http_payload": map[string]interface{}{
-					"type":         step.Request.HTTPPayload.RequestBody.Type,
-					"request_body": step.Request.HTTPPayload.RequestBody.Content,
+					"type":           step.Request.HTTPPayload.RequestBody.Type,
+					"request_body":   step.Request.HTTPPayload.RequestBody.Content,
 					"authentication": step.Request.HTTPPayload.Authentication,
-					"cookies":      step.Request.HTTPPayload.Cookies,
+					"cookies":        step.Request.HTTPPayload.Cookies,
 				},
 				"assertions": step.Request.Assertions.HTTP.Cases,
 			},

--- a/pkg/worker/k6.osexec.go
+++ b/pkg/worker/k6.osexec.go
@@ -3,10 +3,10 @@ package worker
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -16,23 +16,7 @@ type k6Scripter interface {
 
 type defaultK6Scripter struct{}
 
-func readStdoutPipeLines(pipe io.Reader) ([]byte, error) {
-	var outputBytes []byte
-	buf := make([]byte, 1024)
-	for {
-		n, err := pipe.Read(buf)
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
-		if n == 0 {
-			break
-		}
-		outputBytes = append(outputBytes, buf[:n]...)
-	}
-	return outputBytes, nil
-}
-
-func findValueToPattern(input string, pattern string) string {
+func findValueToPattern(input string, pattern string) (string, error) {
 	val := ""
 	re := regexp.MustCompile(pattern)
 	match := re.FindStringSubmatch(string(input))
@@ -41,13 +25,7 @@ func findValueToPattern(input string, pattern string) string {
 	}
 	re = regexp.MustCompile(`\\/"`)
 	val = re.ReplaceAllString(val, `"`)
-
-	re1 := regexp.MustCompile(`\\\\"`)
-	val = re1.ReplaceAllString(val, `\"`)
-
-	re2 := regexp.MustCompile(`\\"`)
-	val = re2.ReplaceAllString(val, `"`)
-	return val
+	return strconv.Unquote("\"" + val + "\"")
 }
 
 func (k6Scripter *defaultK6Scripter) execute(scriptSnippet string) (string, error) {
@@ -67,39 +45,13 @@ func (k6Scripter *defaultK6Scripter) execute(scriptSnippet string) (string, erro
 	}
 
 	cmd := exec.Command("k6", "run", temp.Name())
-
-	/*stdoutPipe, outErr := cmd.StdoutPipe()
-	if outErr != nil {
-		return "", fmt.Errorf("error creating stdout pipe: %s", outErr.Error())
-	}*/
-	stderrPipe, stdErr := cmd.StderrPipe()
-	if stdErr != nil {
-		return "", fmt.Errorf("error creating stderr pipe: %s", stdErr.Error())
-	}
-
-	if err := cmd.Start(); err != nil {
-		return "", fmt.Errorf("error starting k6 command: %s", err.Error())
-	}
-
-	/*outputBytes, err := readStdoutPipeLines(stdoutPipe)
+	outputBytes, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("error reading stdout: %s", err.Error())
-	}*/
-	errorOutputBytes, err := readStdoutPipeLines(stderrPipe)
-	if err != nil {
-		return "", fmt.Errorf("error reading stderr: %s", err.Error())
-	}
-
-	// Wait for the k6 command to finish.
-	if wErr := cmd.Wait(); wErr != nil {
-		return "", fmt.Errorf("k6 command finished with error: %s", wErr.Error())
+		return "", fmt.Errorf("error executing k6 script: %s", err.Error())
 	}
 
 	pattern1 := `###START->([^=]+)<-END###`
-	respValue := findValueToPattern(string(errorOutputBytes), pattern1)
-	/*if respValue == "" {
-		respValue = findValueToPattern(string(outputBytes), pattern1)
-	}*/
+	return findValueToPattern(string(outputBytes), pattern1)
 
 	//pattern2 := `###OTHER_START->([^=]+)<-OTHER_START###`
 	//other := findValueToPattern(string(errorOutputBytes), pattern2)
@@ -107,8 +59,6 @@ func (k6Scripter *defaultK6Scripter) execute(scriptSnippet string) (string, erro
 	//
 	//fmt.Println("other--->", other)
 	//fmt.Println("other2--->", other2)
-
-	return respValue, nil
 }
 
 func CreateScriptSnippet(req SyntheticCheck) string {

--- a/pkg/worker/k6.osexec_test.go
+++ b/pkg/worker/k6.osexec_test.go
@@ -1,0 +1,66 @@
+package worker
+
+import (
+	"testing"
+)
+
+var inputJSON string = "{" +
+	"\\\"steps\\\": \\\"step1\\\\\\\"E\\\"," +
+	"\\\"multiStepPreview\\\": true }"
+
+var expectedJSON = `{"steps": "step1\"E","multiStepPreview": true }`
+
+func TestFindValueToPattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		pattern  string
+		expected string
+		errMsg   string
+	}{
+		{
+			name:     "valid pattern",
+			input:    `###START->Hello<-END###`,
+			pattern:  `###START->([^=]+)<-END###`,
+			expected: "Hello",
+		},
+		{
+			name:     "valid pattern with escape characters",
+			input:    "###START->" + inputJSON + "<-END###",
+			pattern:  `###START->([^=]+)<-END###`,
+			expected: expectedJSON,
+		},
+		{
+			name:     "invalid pattern",
+			input:    `###START->Hello<-END###`,
+			pattern:  `###OTHER_START->([^=]+)<-OTHER_START###`,
+			expected: "",
+		},
+		{
+			name:     "invalid pattern with escape characters",
+			input:    "###START->" + inputJSON + "<-END###",
+			pattern:  `###OTHER_START->([^=]+)<-OTHER_START###`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			result, err := findValueToPattern(tt.input, tt.pattern)
+
+			if err != nil {
+				if err.Error() != tt.errMsg {
+					t.Errorf("%s: Expected error message %s, but got %s", tt.name, tt.errMsg, err.Error())
+				}
+
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("%s: Expected %s, but got %s", tt.name, tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR include fix for two issues

- `k6` sends output to `stderr` . So synthetic agent should not be blocking on `stdout` when `k6` is shelled out.
- Improved JSON parsing for escaped `\` and `\"` .